### PR TITLE
add snapcraft configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.snap
 # Logs
 logs
 *.log

--- a/greenhouse.js
+++ b/greenhouse.js
@@ -1,0 +1,3 @@
+#!/bin/env node
+require("./index.js");
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,72 @@
+name: greenhouse
+version: "1.0.0"
+summary: Perform actions in Canonical's Greenhouse automatically.
+description: An automated browser that does a set of tasks on Canonical's Greenhouse dashboard without the need of interaction with the UI.
+base: core20
+confinement: strict
+grade: stable
+issues: https://github.com/canonical/greenhouse-automations/issues
+source-code: https://github.com/canonical/greenhouse-automations
+
+parts:
+    node:
+        plugin: dump
+        source: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-x64.tar.xz
+        stage:
+            - bin
+            - include
+            - lib
+    greenhouse:
+        after: [node]
+        plugin: nil
+        source: .
+        override-build: |
+            npm config set unsafe-perm true
+            npm install -g yarn
+            yarn install
+            yarn build
+            cp ./greenhouse.js ./dist/greenhouse
+            cp -a ./dist/. $SNAPCRAFT_PART_INSTALL/
+            cp -r ./node_modules $SNAPCRAFT_PART_INSTALL
+        stage-packages:
+            # dependencies required by chromium
+            - libasound2
+            - libatk-bridge2.0-0
+            - libatk1.0-0
+            - libatspi2.0-0
+            - libcairo2
+            - libcups2
+            - libdrm2
+            - libgbm1
+            - libnss3
+            - libpango-1.0-0
+            - libx11-6
+            - libxau6
+            - libxcb1
+            - libxcomposite1
+            - libxdamage1
+            - libxdmcp6
+            - libxext6
+            - libxfixes3
+            - libxkbcommon-x11-0
+            - libxrandr2
+apps:
+    greenhouse:
+        command: greenhouse
+        plugs:
+            - browser-sandbox
+            - desktop
+            - desktop-legacy
+            - home
+            - mount-observe
+            - network
+            - network-bind
+            - opengl
+            - unity7
+            - x11
+
+plugs:
+    browser-sandbox:
+        interface: browser-support
+        allow-sandbox: true
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ async function addPosts(jobID: number, regions: string[], cloneFrom: number) {
     const loginCookies = await sso.login();
     console.log(green("✓"), "Authentication complete");
 
-    const browser = await Puppeteer.launch();
+    const browser = await Puppeteer.launch({ args: ["--no-sandbox"] });
     const page = await browser.newPage();
     await sso.setCookies(page, loginCookies);
 


### PR DESCRIPTION
## Done

- Snapcraft configuration

## QA

- Install snapcraft: `snap install --classic snapcraft`
- Build the snap (the first time will be long, and install's multipass): `snapcraft`
- Make sure there is no error and a file called `greenhouse_1.0.0_amd64.snap` is generated
- Install the snap: `snap install --dangerous greenhouse_1.0.0_amd64.snap`
- Make sure that the app works: `greenhouse ...`

## Issues

Fixes https://github.com/canonical/workplace-engineering-squad/issues/315

## Screenshots

### The working snap
![image](https://user-images.githubusercontent.com/36013798/153678381-f228763e-31f0-4206-931e-a8cbb9866ab4.png)

