### PR TITLE
Remove unsupported links by review tools from snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,8 +5,6 @@ description: An automated browser that does a set of tasks on Canonical's Greenh
 base: core20
 confinement: strict
 grade: stable
-issues: https://github.com/canonical/greenhouse-automations/issues
-source-code: https://github.com/canonical/greenhouse-automations
 
 parts:
     node:


### PR DESCRIPTION
Links are not supported yet by the review tools. The warning triggers a manual review each time we build.

Let's get rid of those for now.