### PR TITLE
Added renovate rule to restrict node-fetch and ora packages versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,13 +4,21 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["node-fetch"],
+      "matchPackageNames": [
+        "node-fetch"
+      ],
       "allowedVersions": "<=2.6.7"
-    }, {
-      "matchPackageNames": ["@types/node-fetch"],
+    },
+    {
+      "matchPackageNames": [
+        "@types/node-fetch"
+      ],
       "allowedVersions": "<=2.6.1"
-    }, {
-      "matchPackageNames": ["ora"],
+    },
+    {
+      "matchPackageNames": [
+        "ora"
+      ],
       "allowedVersions": "<=5.4.1"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,17 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["node-fetch"],
+      "allowedVersions": "<=2.6.7"
+    }, {
+      "matchPackageNames": ["@types/node-fetch"],
+      "allowedVersions": "<=2.6.1"
+    }, {
+      "matchPackageNames": ["ora"],
+      "allowedVersions": "<=5.4.1"
+    }
   ]
 }


### PR DESCRIPTION
## Done
- "node-fetch" package's version should be limited to 2.6.7.
- "@types/node-fetch" package's version should be limited to 2.6.1.
- "ora" package's version should be limited to 5.4.1.

Fixes #36 