### PR TITLE
Updated add-post command's name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -232,7 +232,7 @@ async function main() {
     };
 
     program
-        .command("add-post")
+        .command("add-posts")
         .addArgument(
             new Argument("<job-id>", "job to add job posts to")
                 .argOptional()


### PR DESCRIPTION
## Done
- "add-command" is changed to "add-commands".

## QA
- Checkout the feature branch
- Install dependencies with `yarn`
- Update "Job.ts" > "clonePost" method > boardPost variable :
`const boardToPost = boards.find((board) => board.name === "Test Board");`
- Run `ts-node ./src/index.ts add-posts -i`
- Select one of the jobs.
- Select one of the job posts.
- Verify regions are listed.
- Press enter without selecting any region
- Select one or more  regions by using space
- Verify job posts are created with entered values.

## Issue
Fixes  #388