### PR TITLE
Filtered displayed job posts

### DIFF
--- a/src/automations/JobPost.ts
+++ b/src/automations/JobPost.ts
@@ -136,9 +136,13 @@ export default class JobPost {
 
         // set the new location
         jobApplication.job_post_location.text_value = location;
+        jobApplication.job_post_location.job_post_location_type = {
+            id: 1, name: 'Free Text', key: 'FREE_TEXT'
+        };
+
+        jobApplication.job_post_location.custom_location = null;
         // set the title
         jobApplication.title = jobPost.name;
-
         const payload = {
             external_or_internal_greenhouse_job_board_id: boardID,
             greenhouse_job_application: jobApplication,


### PR DESCRIPTION
## Done
- Job posts that are displayed in CLI is filtered by board. Only posts in "Canonical" board will be displayed.

## QA
- Checkout the feature branch
- Install dependencies with `yarn`
- Update "Job.ts" > "clonePost" method > boardPost variable :
`const boardToPost = boards.find((board) => board.name === "Test Board");`
- Run `ts-node ./src/index.ts add-job -i`
- Select "[Demo Job - Scenario A](https://canonical.greenhouse.io/sdash/1753300)". (It has a job post in "Canonical" board)
- Verify only job posts that are in "Canonical" board are displayed. (In this case "A test")
- Select "A test" job post.
- Select a region.
- Verify job posts are created with entered values.

## Issue
Fixes  #386
