### PR TITLE
Rename snap to `ghtctl`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: greenhouse
+name: ghtctl
 version: "1.0.0"
 summary: Perform actions in Canonical's Greenhouse automatically.
 description: An automated browser that does a set of tasks on Canonical's Greenhouse dashboard without the need of interaction with the UI.
@@ -51,7 +51,7 @@ parts:
             - libxkbcommon-x11-0
             - libxrandr2
 apps:
-    greenhouse:
+    ghtctl:
         command: greenhouse
         plugs:
             - desktop
@@ -63,4 +63,3 @@ apps:
             - opengl
             - unity7
             - x11
-

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ parts:
             - bin
             - include
             - lib
-    greenhouse:
+    ghtctl:
         after: [node]
         plugin: nil
         source: .
@@ -25,7 +25,7 @@ parts:
             yarn build
             # this causes PROT_EXEC problem
             rm ./node_modules/puppeteer/.local-chromium/linux-*/chrome-linux/nacl_irt_*.nexe
-            cp ./greenhouse.js ./dist/greenhouse
+            cp ./greenhouse.js ./dist/ghtctl
             cp -a ./dist/. $SNAPCRAFT_PART_INSTALL/
             cp -r ./node_modules $SNAPCRAFT_PART_INSTALL
         stage-packages:
@@ -52,7 +52,7 @@ parts:
             - libxrandr2
 apps:
     ghtctl:
-        command: greenhouse
+        command: ghtctl
         plugs:
             - desktop
             - desktop-legacy


### PR DESCRIPTION
## Done

- Rename snap from `greenhouse` to `ghtctl`

## QA 

- Install snapcraft (if not already installed): `snap install --classic snapcraft`
- Build the snap with `snapcraft`
- Install the snap: `snap install --dangerous ghtctl_1.0.0_amd64.snap`
- Check if it works, e.g. `ghtctl delete-posts --help`

## Issue

Fixes #57 