### PR TITLE
Fixed typo in "credentials"

### DIFF
--- a/src/automations/SSO.ts
+++ b/src/automations/SSO.ts
@@ -80,7 +80,7 @@ export default class SSO {
         this.spinner.start("Checking authentication...");
         let sessionId = await this.currentSessionId();
         if ((await this.isLoggedIn()) && sessionId) {
-            this.spinner.succeed("Using the saved creadentials.");
+            this.spinner.succeed("Using the saved credentials.");
             return { sessionId: sessionId };
         }
         this.spinner.stop();


### PR DESCRIPTION
## Done
Fixed typo in "credentials"

## QA 
- Run `ts-node ./src/index.ts replicate -i` command
- Enter credentials
- Wait for success message
- Stop the program
- Re-run `ts-node ./src/index.ts replicate -i` command
- Verify the log "Using the saved credentials." is displayed correctly.

Fixes #62  