### PR TITLE
Replaced job id argument with job post id

### DIFF
--- a/src/automations/Job.ts
+++ b/src/automations/Job.ts
@@ -144,15 +144,15 @@ export default class Job {
     }
 
     public async getJobData(jobID: number): Promise<JobInfo> {
-        const jobappURL = joinURL(MAIN_URL, `/plans/${jobID}/jobapp`);
-        await this.page.goto(jobappURL);
-        const jobTitle = await this.getJobName();
+        const jobTitle = await this.getJobName(jobID);
         const job: JobInfo = {
             name: jobTitle,
             id: jobID,
             posts: [],
         };
 
+        const jobappURL = joinURL(MAIN_URL, `/plans/${jobID}/jobapp`);
+        await this.page.goto(jobappURL);
         const pageCount = await this.getPageCount();
         for (let currentPage = 1; currentPage <= pageCount; currentPage++) {
             await this.page.goto(`${jobappURL}?page=${currentPage}`);
@@ -247,7 +247,9 @@ export default class Job {
         return jobPosts;
     }
 
-    public async getJobName(): Promise<string> {
+    public async getJobName(jobID: number): Promise<string> {
+        await this.page.goto(joinURL(MAIN_URL, `/plans/${jobID}`));
+
         const jobTitleElement = await this.page.$(".job-name");
         const jobAnchor = await jobTitleElement?.$("a");
         if (!jobAnchor) throw new Error("Cannot find the job's name.");
@@ -307,5 +309,12 @@ export default class Job {
         }
 
         return jobs;
+    }
+
+    public async getJobIDFromPost(postID: number) {
+        await this.page.goto(joinURL(MAIN_URL, `/jobapps/${postID}/edit`));
+        const jobElement = await this.page.$(".job-name");
+        if (!jobElement) throw new Error("Job cannot be found.");
+        return await getIDFromURL(jobElement, "a");
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,8 +94,7 @@ async function deletePostsInteractive(
 async function addPosts(
     isInteractive: boolean,
     postIDArg: number,
-    regionsArg: string[],
-    cloneFromArg: number
+    regionsArg: string[]
 ) {
     const spinner = ora();
     let currentBrowser;
@@ -109,7 +108,7 @@ async function addPosts(
         let jobID;
         let jobInfo: JobInfo;
         let regionNames = regionsArg;
-        let cloneFrom = cloneFromArg;
+        let cloneFrom;
         if (isInteractive) {
             const { name, id } = await getJobInteractive(
                 job,
@@ -283,10 +282,9 @@ async function main() {
         )
         .command("replicate")
         .usage(
-            "([-i | --interactive] | <job-id> --regions=<region-name>[, <region-name-2>...]" +
-                " [--clone-from=<job-post-id>]) \n\n Examples: \n\t greenhouse replicate --interactive " +
-                "\n \t greenhouse replicate 1234 --regions=emea,americas \n \t greenhouse replicate 1234" +
-                " --regions=emea --clone-from=1123"
+            "([-i | --interactive] | <job-post-id> --regions=<region-name>[, <region-name-2>...])" +
+                "\n\n Examples: \n\t greenhouse replicate --interactive " +
+                "\n \t greenhouse replicate 1234 --regions=emea,americas"
         )
         .description(
             "Create job post for a specific job in the specified regions from all existing " +
@@ -294,19 +292,13 @@ async function main() {
         )
         .addArgument(
             new Argument(
-                "<job-id>",
-                "ID of a job that job posts will be created to"
+                "<job-post-id>",
+                "ID of a job post that will be cloned from"
             )
                 .argOptional()
                 .argParser((value: string) =>
-                    validateNumberParam(value, "job-id")
+                    validateNumberParam(value, "job post id")
                 )
-        )
-        .addOption(
-            new Option(
-                "-c, --clone-from <job-post-id>",
-                "Clone job posts from the given post"
-            ).argParser((value) => validateNumberParam(value, "post-id"))
         )
         .addOption(
             new Option(
@@ -317,12 +309,11 @@ async function main() {
         .addOption(
             new Option("-i, --interactive", "Enable interactive interface")
         )
-        .action(async (jobID, options) => {
+        .action(async (jobPostID, options) => {
             await addPosts(
                 options.interactive,
-                jobID,
-                options.regions,
-                options.cloneFrom
+                jobPostID,
+                options.regions
             );
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,7 @@ import { JobInfo, PostInfo } from "./common/types";
 import regions from "./common/regions";
 import Job from "./automations/Job";
 import SSO from "./automations/SSO";
-import { MAIN_URL, PROTECTED_JOB_BOARDS } from "./common/constants";
-import { joinURL } from "./common/pageUtils";
+import { PROTECTED_JOB_BOARDS } from "./common/constants";
 import { Command, Argument, Option } from "commander";
 import { green } from "colors";
 import ora from "ora";
@@ -94,7 +93,7 @@ async function deletePostsInteractive(
 
 async function addPosts(
     isInteractive: boolean,
-    jobIDArg: number,
+    postIDArg: number,
     regionsArg: string[],
     cloneFromArg: number
 ) {
@@ -107,7 +106,7 @@ async function addPosts(
         currentBrowser = browser;
         const job = new Job(page, spinner);
 
-        let jobID = jobIDArg;
+        let jobID;
         let jobInfo: JobInfo;
         let regionNames = regionsArg;
         let cloneFrom = cloneFromArg;
@@ -139,15 +138,15 @@ async function addPosts(
 
             await deletePostsInteractive(job, jobInfo, regionNames, cloneFrom);
         } else {
-            if (!jobID) throw Error(`Job ID argument is missing.`);
+            if (!postIDArg) throw Error(`Job post ID argument is missing.`);
             if (!regionNames) throw Error(`Region parameter is missing.`);
+            cloneFrom = postIDArg;
 
-            await page.goto(joinURL(MAIN_URL, `/plans/${jobID}`));
-
-            const name = await job.getJobName();
-            spinner.start(`Fetching job posts for ${name}.`);
+            spinner.start(`Fetching thejob information.`);
+            jobID = await job.getJobIDFromPost(postIDArg);
             jobInfo = await job.getJobData(jobID);
             spinner.succeed();
+
             if (jobInfo.posts.length === 0)
                 throw Error(
                     "Only hiring leads can create job posts. If you are not sure about your hiring role please contact HR."
@@ -234,8 +233,7 @@ async function deletePosts(
         } else {
             if (!jobID) throw Error(`Job ID argument is missing.`);
 
-            await page.goto(joinURL(MAIN_URL, `/plans/${jobID}`));
-            const name = await job.getJobName();
+            const name = await job.getJobName(jobID);
             spinner.start(`Fetching job posts for ${name}.`);
             jobInfo = await job.getJobData(jobID);
             spinner.succeed();


### PR DESCRIPTION
## Done
- Removed job id argument from the "replicate" command
- Added job post id argument 
- job id is retrieved by using job post.

## QA
- Checkout the feature branch
- Update dependencies with `yarn` command.
- Run `ts-node ./src/index.ts replicate <job-post-id> -r emea` command
- Verify posts are created correctly
- Run `ts-node ./src/index.ts replicate -i`
- Select necessary options from CLI
- Verify posts are created correctly

Fixes https://github.com/canonical/greenhouse-automations/issues/53