### PR TITLE
Filled free job post board information

### DIFF
--- a/src/automations/JobPost.ts
+++ b/src/automations/JobPost.ts
@@ -242,6 +242,10 @@ export default class JobPost {
         const locationInfo = await this.getLocationInfo(location, jobPost.id);
         jobApplication["job_board_feed_location_attributes"] = locationInfo;
 
+        FILTERED_ATTRIBUTES.forEach((attr) => {
+            delete payload.greenhouse_job_application[attr];
+        });
+
         await sendRequest(
             this.page,
             joinURL(MAIN_URL, `/plans/${jobPost.job.id}/jobapps`),

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,11 +310,7 @@ async function main() {
             new Option("-i, --interactive", "Enable interactive interface")
         )
         .action(async (jobPostID, options) => {
-            await addPosts(
-                options.interactive,
-                jobPostID,
-                options.regions
-            );
+            await addPosts(options.interactive, jobPostID, options.regions);
         });
 
     program


### PR DESCRIPTION
## Done
- Fetched predefined locations to fill position information
- Filled free board information in job posts (Indeed and Remote fields are set to true)

## QA
- Checkout the feature branch
- Install dependencies with `yarn`
- Run ` ts-node ./src/index.ts replicate -i` command
- Select necessary options
- Verify job posts are created.
- Verify "Indeed" and "Remote" checkboxes are enabled in the  "Publish to Free Job Boards" section
- Verify "Location" field is filled correctly in the  "Publish to Free Job Boards" section

Fixes #66 