### PR TITLE
fix: correct path in error message when no graders file found

### DIFF
--- a/src/controllers/AssignGradersController.ts
+++ b/src/controllers/AssignGradersController.ts
@@ -112,7 +112,7 @@ export class AssignGradersController extends BaseController {
 
         if (!gradersConfig) {
             throw new UserError(
-                "Unable to find list of graders. Please ensure 'ght-graders.yml' is present at either '$HOME/ght-graders.yml' or '$HOME/.config/ght-graders.yml'.",
+                "Unable to find list of graders. Please ensure 'ght-graders.yml' is present at either '$HOME/ght-graders.yml' or '$HOME/.config/ght/ght-graders.yml'.",
             );
         }
 


### PR DESCRIPTION
Minor fix to a previous commit I made - the search path in the error message is incorrect.